### PR TITLE
Fix broken build process - updated through2 dep to v3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "cheerio": "1.0.0-rc.2",
     "lodash": "^4.6.1",
     "tinyliquid": "^0.2.31",
-    "through2": "^2.0.1"
+    "through2": "3.0.1"
   },
   "devDependencies": {
     "jasmine": "^2.8.0",


### PR DESCRIPTION
Hi!

## What change does this produce
- Fix broken build process - updated `through2` dep to `v3.0.1`

## Does this cause any breaking changes
- No

## Any other notes
- Make sure to merge in the following PRs associated with the `magicbook-katex` and `magicbook` which are also using an old version of `through2` 